### PR TITLE
Proxy autocomplete through backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # property-estimator
+
+## Backend configuration
+
+Autocomplete suggestions are now proxied through the backend so the Geoapify
+API key is never exposed to the browser. Configure the backend (e.g. the AWS
+Lambda behind `API_URL`) with the following environment variable:
+
+| Variable           | Description                              |
+| ------------------ | ---------------------------------------- |
+| `GEOAPIFY_API_KEY` | Geoapify API key used for autocomplete.  |
+
+The Lambda function should expose a `GET /autocomplete` route that invokes the
+code in `lambda/autocomplete.js`. The handler reads the API key from the
+environment variable, calls Geoapify, and returns the JSON payload directly to
+the frontend. Remember to redeploy the Lambda after updating the environment
+variable so the new configuration takes effect.
+
+For local development you can set the environment variable before running the
+Lambda locally:
+
+```bash
+export GEOAPIFY_API_KEY=your-key-here
+```
+
+If you deploy the backend somewhere else (e.g. Express, API Gateway), ensure
+the same route and environment variable are configured so `app.js` can reach
+`<API_URL>/autocomplete?text=...` for address suggestions.
  

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 const API_URL =
   "https://g7eku3ruwr6e2hduscxavmi6zy0wsiel.lambda-url.ap-southeast-2.on.aws/";
-const GEOAPIFY_KEY = "8fa427a20e3d4b73b081e0864e12c16c";
+const AUTOCOMPLETE_URL = `${API_URL}autocomplete`;
 
 function setLoading(isLoading) {
   const btn = document.getElementById("searchBtn");
@@ -19,12 +19,16 @@ async function fetchSuggestions(query) {
   box.innerHTML = "";
   if (query.length < 3) return;
 
-  const url = `https://api.geoapify.com/v1/geocode/autocomplete?text=${encodeURIComponent(
-    query
-  )}&apiKey=${GEOAPIFY_KEY}`;
-
   try {
-    const data = await fetch(url).then((r) => r.json());
+    const url = new URL(AUTOCOMPLETE_URL);
+    url.searchParams.set("text", query);
+
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Autocomplete failed: ${res.status}`);
+    }
+
+    const data = await res.json();
     data.features.forEach((f) => {
       const div = document.createElement("div");
       div.textContent = f.properties.formatted;

--- a/lambda/autocomplete.js
+++ b/lambda/autocomplete.js
@@ -1,0 +1,85 @@
+const GEOAPIFY_API_KEY = process.env.GEOAPIFY_API_KEY;
+
+const BASE_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+const AUTOCOMPLETE_ENDPOINT =
+  "https://api.geoapify.com/v1/geocode/autocomplete";
+
+exports.handler = async (event) => {
+  const method =
+    event?.requestContext?.http?.method || event?.httpMethod || "GET";
+
+  if (method === "OPTIONS") {
+    return {
+      statusCode: 204,
+      headers: BASE_HEADERS,
+      body: "",
+    };
+  }
+
+  if (method !== "GET") {
+    return {
+      statusCode: 405,
+      headers: BASE_HEADERS,
+      body: JSON.stringify({ message: "Method Not Allowed" }),
+    };
+  }
+
+  if (!GEOAPIFY_API_KEY) {
+    return {
+      statusCode: 500,
+      headers: BASE_HEADERS,
+      body: JSON.stringify({ message: "Geoapify API key is not configured." }),
+    };
+  }
+
+  const query = event?.queryStringParameters?.text || "";
+  const searchText = query.trim();
+
+  if (!searchText) {
+    return {
+      statusCode: 400,
+      headers: BASE_HEADERS,
+      body: JSON.stringify({ message: "Query parameter 'text' is required." }),
+    };
+  }
+
+  try {
+    const url = new URL(AUTOCOMPLETE_ENDPOINT);
+    url.searchParams.set("text", searchText);
+    url.searchParams.set("apiKey", GEOAPIFY_API_KEY);
+
+    const response = await fetch(url.toString());
+
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        statusCode: response.status,
+        headers: BASE_HEADERS,
+        body: JSON.stringify({
+          message: "Failed to fetch suggestions from Geoapify.",
+          details: body,
+        }),
+      };
+    }
+
+    const payload = await response.json();
+    return {
+      statusCode: 200,
+      headers: {
+        ...BASE_HEADERS,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      headers: BASE_HEADERS,
+      body: JSON.stringify({ message: "Autocomplete lookup failed.", error: error.message }),
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- add an AWS Lambda handler that proxies autocomplete requests to Geoapify using a secure environment variable
- switch the frontend autocomplete requests to call the backend endpoint instead of Geoapify directly
- document the new GEOAPIFY_API_KEY configuration requirement for deployments

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cfef600d508328879f358cff2170cf